### PR TITLE
Add option to delete extraneous items

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-import {basicTypes, CheckerFunc, ITypeSuite, TFunc, TIface, TType} from "./types";
+import {basicTypes, CheckerFunc, Extras, ITypeSuite, TFunc, TIface, TType} from "./types";
 import {DetailContext, IErrorDetail, NoopContext} from "./util";
 
 /**
@@ -44,6 +44,7 @@ export class Checker {
   private props: Map<string, TType> = new Map();
   private checkerPlain: CheckerFunc;
   private checkerStrict: CheckerFunc;
+  private checkerDelete: CheckerFunc;
 
   // Create checkers by using `createCheckers()` function.
   constructor(private suite: ITypeSuite, private ttype: TType, private _path: string = 'value') {
@@ -52,8 +53,9 @@ export class Checker {
         this.props.set(p.name, p.ttype);
       }
     }
-    this.checkerPlain = this.ttype.getChecker(suite, false);
-    this.checkerStrict = this.ttype.getChecker(suite, true);
+    this.checkerPlain = this.ttype.getChecker(suite, Extras.ignore);
+    this.checkerStrict = this.ttype.getChecker(suite, Extras.error);
+    this.checkerDelete = this.ttype.getChecker(suite, Extras.delete);
   }
 
   /**
@@ -107,6 +109,12 @@ export class Checker {
   public strictValidate(value: any): IErrorDetail|null {
     return this._doValidate(this.checkerStrict, value);
   }
+
+  /**
+   * Check that the given value satisfies this checker's type, or throw Error.
+   * Extra members in objects and tuples will be deleted in place.
+   */
+  public checkAndDeleteExtras(value: any): void { return this._doCheck(this.checkerDelete, value); }
 
   /**
    * If this checker is for an interface, returns a Checker for the type required for the given

--- a/test/test_checker.ts
+++ b/test/test_checker.ts
@@ -558,6 +558,14 @@ describe("ts-interface-checker", () => {
     assert.instanceOf(Greeter.getType(), t.TIface);
   });
 
+  it("should allow deleting extraneous properties", () => {
+    const {Shape} = createCheckers(shapes);
+    const square = {kind: "square", size: 17, depth: 5};
+    Shape.checkAndDeleteExtras(square);
+    assert.deepEqual(square as any, {kind: "square", size: 17});
+    assert.throws(() => Shape.checkAndDeleteExtras({}), /value.kind is missing$/);
+  });
+
   it("should allow getting error details", () => {
     const {Shape} = createCheckers(shapes);
     const {Type} = createCheckers({


### PR DESCRIPTION
Fixes https://github.com/gristlabs/ts-interface-checker/issues/10, hopefully

This is compared against my other PR https://github.com/gristlabs/ts-interface-checker/pull/47 which should be sorted out first. Currently this just demonstrates the idea and the ramifications for the API. The new function checkAndDeleteExtras is not meant to stay that way.

Returning a new object copied from the original is hard, this implementation deletes extra values in place. If users don't want to modify the original object then they must use another library to make a deep copy of the object first.

If you pass invalid data, it may be modified before the check fails and throws an error. Those modifications are not rolled back.

If you have a union where the properties of one type are a subset of another, e.g:

```ts
interface A {
    a: any
}

interface B {
    a: any
    b: any
}

type AorB = A | B
```

then checking against the union may match `A` first and delete the property `b` as extraneous.